### PR TITLE
feat: 댓글 삭제 기능 추가

### DIFF
--- a/src/main/java/com/sparta/newsfeedproject/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/sparta/newsfeedproject/domain/comment/controller/CommentController.java
@@ -23,11 +23,12 @@ public class CommentController {
     private final JwtUtil jwtUtil;
     private final MemberService memberService;
 
+    //댓글 작성
     @PostMapping("/{postId}/comments")
     public ResponseEntity<CommentResponseDto> createComment(
             @PathVariable Long postId,
             @RequestBody CommentRequestDto requestDto,
-            HttpServletRequest request //Spring Security+JWT 인증 이후에 @AuthenticationPrincipal UserDetailsImpl 로 파라미터를 받는부분 필요
+            HttpServletRequest request
     ) {
         // Member 객체 조회
         Member member = (Member) request.getAttribute("member");
@@ -35,6 +36,7 @@ public class CommentController {
         return new ResponseEntity<>(responseDto, HttpStatus.CREATED);
     }
 
+    //댓글 수정
     @PutMapping("/{postId}/comments/{commentId}")
     public ResponseEntity<CommentResponseDto> updateComment(
             @PathVariable Long postId,
@@ -44,11 +46,19 @@ public class CommentController {
     ) {
         // Member 객체 조회
         Member member = (Member) request.getAttribute("member");
-        if(member == null) {
-            log.info("유효하지 않은 사용자 입니다.");
-            return new ResponseEntity<>(HttpStatus.UNAUTHORIZED);
-        }
         CommentResponseDto responseDto = commentService.updateComment(postId, commentId, requestDto, member);
         return ResponseEntity.ok(responseDto);
+    }
+
+    //댓글 삭제
+    @DeleteMapping("/{postId}/comments/{commentId}")
+    public ResponseEntity<String> deleteComment(
+            @PathVariable Long postId,
+            @PathVariable Long commentId,
+            HttpServletRequest request
+    ) {
+        Member member = (Member) request.getAttribute("member");
+        commentService.deleteComment(postId, commentId, member);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 }

--- a/src/main/java/com/sparta/newsfeedproject/domain/comment/service/CommentService.java
+++ b/src/main/java/com/sparta/newsfeedproject/domain/comment/service/CommentService.java
@@ -42,4 +42,12 @@ public class CommentService {
         commentRepository.saveAndFlush(comment);
         return new CommentResponseDto(comment);
     }
+
+    @Transactional
+    public void deleteComment(Long postId, Long commentId, Member member) {
+        Post post = postRepository.findById(postId).orElseThrow(() -> new IllegalArgumentException("해당 게시글이 존재하지 않습니다."));
+        Comment comment = commentRepository.findById(commentId).orElseThrow(() -> new IllegalArgumentException("해당 댓글이 존재하지 않습니다."));
+        if(!comment.getMember().getId().equals(member.getId())) throw new SecurityException("본인의 댓글만 삭제할 수 있습니다.");
+        commentRepository.delete(comment);
+    }
 }


### PR DESCRIPTION
- JWT 토큰을 쿠키에서 받아와 사용자를 검증하여 본인 댓글만 삭제할 수 있도록 구현
- 게시글 및 댓글의 존재 여부에 대한 예외 처리 추가
- 댓글 삭제 시 권한이 없는 사용자가 접근할 경우 예외 발생 처리

Refs: #13